### PR TITLE
added lib to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ rockstar-galaxies: $(OFILES)
 %.o: %.c
 	$(CC) $(CFLAGS) $(OFLAGS) -c $*.c -o $@
 
+lib:
+	$(CC) $(CFLAGS) $(LDFLAGS) $(OFILES) -o librockstar-galaxies.so $(OFLAGS) $(EXTRA_FLAGS)
+
 #all:
 #	@make reg EXTRA_FLAGS="$(OFLAGS)"
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ rockstar-galaxies: $(OFILES)
 %.o: %.c
 	$(CC) $(CFLAGS) $(OFLAGS) -c $*.c -o $@
 
-lib:
+lib: all
 	$(CC) $(CFLAGS) $(LDFLAGS) $(OFILES) -o librockstar-galaxies.so $(OFLAGS) $(EXTRA_FLAGS)
 
 #all:


### PR DESCRIPTION
brings back `make lib` which generates `librockstar-galaxies.so` for use with yt-project/yt_astro_analysis [Installing with Rockstar support](https://github.com/yt-project/yt_astro_analysis#installing-with-rockstar-support). 